### PR TITLE
[GML] Update SDPA ReduceOpVariants pattern after rebase

### DIFF
--- a/lib/Dialect/Torch/Transforms/ReduceOpVariants.cpp
+++ b/lib/Dialect/Torch/Transforms/ReduceOpVariants.cpp
@@ -269,6 +269,9 @@ void TorchMatchSpecializedBackendOp::populateSpecializedConversions(
           llvm::SmallVector<Value> newOperands{
               oldOperands[0], oldOperands[1], oldOperands[2], oldOperands[3],
               oldOperands[4], oldOperands[5], oldOperands[7]};
+          Value enableGQA =
+              rewriter.create<ConstantBoolOp>(op->getLoc(), false);
+          newOperands.push_back(enableGQA);
 
           auto newOp = rewriter.create<Torch::AtenScaledDotProductAttentionOp>(
               op.getLoc(), op->getResultTypes()[0], newOperands,


### PR DESCRIPTION
I rebased to a newer version of torch-mlir which changed the signature of the `scaled_dot_product_attention` op. I forgot to update this call site to include the new GQA parameter.
