### PR TITLE
Define MemoryEffectOpInterface for all torch ops

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.h
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.h
@@ -23,6 +23,33 @@
 #include "torch-mlir/Dialect/Torch/IR/TorchTraits.h"
 #include "torch-mlir/Dialect/Torch/IR/TorchTypes.h"
 
+namespace mlir {
+namespace OpTrait {
+
+template <typename ConcreteType>
+struct TorchMemoryEffectImplTrait
+    : public TraitBase<ConcreteType, TorchMemoryEffectImplTrait> {
+
+  void
+  getEffects(SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+                 &effects) {
+    auto *op = this->getOperation();
+    for (auto &operand : op->getOpOperands()) {
+      if (operand.get()
+              .getType()
+              .template isa<torch::Torch::NonValueTensorType>()) {
+        // Conservatively assume that all non-value tensor operands are read and
+        // written.
+        effects.emplace_back(MemoryEffects::Read::get(), &operand);
+        effects.emplace_back(MemoryEffects::Write::get(), &operand);
+      }
+    }
+  }
+};
+
+} // namespace OpTrait
+} // namespace mlir
+
 #define GET_OP_CLASSES
 #include "torch-mlir/Dialect/Torch/IR/TorchOps.h.inc"
 

--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -19,8 +19,13 @@ include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
+def TorchMemoryEffectImplTrait : NativeOpTrait<"TorchMemoryEffectImplTrait">;
+
+def TorchMemoryEffectTrait : TraitList<[
+    MemoryEffectsOpInterface, TorchMemoryEffectImplTrait]>;
+
 class Torch_Op<string mnemonic, list<Trait> traits = []>
-    : Op<Torch_Dialect, mnemonic, traits> {
+    : Op<Torch_Dialect, mnemonic, !listconcat(traits, [TorchMemoryEffectTrait])> {
 }
 
 include "torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td"


### PR DESCRIPTION
Defines a MemoryEffectOpInterface default implementation for all torch ops. The implementation ensures that torch ops that only operate on tensors with Value semantics are marked as having no side effects, and operations that operate on tensors with non-value semantics are marked as conservatively having both read and write side effects. This enables folding value-semantics ops that are unused.
