### PR TITLE
[GML] Workaround LLVM RemoveDeadValues bug that means operands are not always defined in getEffects

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.h
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.h
@@ -35,6 +35,9 @@ struct TorchMemoryEffectImplTrait
                  &effects) {
     auto *op = this->getOperation();
     for (auto &operand : op->getOpOperands()) {
+      if (!operand.get()) {
+        continue;
+      }
       if (operand.get()
               .getType()
               .template isa<torch::Torch::NonValueTensorType>()) {


### PR DESCRIPTION
This works around a bug in the RemoveDeadValues pass.
