### PR TITLE
[compiler] add FP4E2M1FN and F8E8M0FNU types

### DIFF
--- a/include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h
@@ -113,7 +113,8 @@ enum class TypeKind {
   _(c10::Float8_e4m3fn, Float8_e4m3fn)     /* 24 */                            \
   _(c10::Float8_e5m2fnuz, Float8_e5m2fnuz) /* 25 */                            \
   _(c10::Float8_e4m3fnuz, Float8_e4m3fnuz) /* 26 */                            \
-  _(c10::qint16, QInt16)                   /* 27 */
+  _(c10::qint16, QInt16)                   /* 27 */                            \
+  _(c10::Float4_e2m1fn, Float4_e2m1fn)     /* 28 */
 
 enum class ScalarType : int8_t {
 #define DEFINE_ENUM(_1, n) n,

--- a/include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h
@@ -114,7 +114,8 @@ enum class TypeKind {
   _(c10::Float8_e5m2fnuz, Float8_e5m2fnuz) /* 25 */                            \
   _(c10::Float8_e4m3fnuz, Float8_e4m3fnuz) /* 26 */                            \
   _(c10::qint16, QInt16)                   /* 27 */                            \
-  _(c10::Float4_e2m1fn, Float4_e2m1fn)     /* 28 */
+  _(c10::Float4_e2m1fn, Float4_e2m1fn)     /* 28 */                            \
+  _(c10::Float8_e8m0fnu, Float8_e8m0fnu)   /* 29 */
 
 enum class ScalarType : int8_t {
 #define DEFINE_ENUM(_1, n) n,

--- a/lib/Dialect/Torch/IR/TorchTypes.cpp
+++ b/lib/Dialect/Torch/IR/TorchTypes.cpp
@@ -192,7 +192,7 @@ static bool isValidTorchDtype(Type dtype) {
   if (isa<Float16Type, BFloat16Type, Float32Type, Float64Type>(dtype))
     return true;
   if (isa<Float8E5M2Type, Float8E4M3FNType, Float8E5M2FNUZType,
-          Float8E4M3FNUZType, Float8E4M3B11FNUZType>(dtype))
+          Float8E4M3FNUZType, Float8E4M3B11FNUZType, Float4E2M1FNType>(dtype))
     return true;
 
   if (isa<Torch::StringType>(dtype))

--- a/lib/Dialect/Torch/IR/TorchTypes.cpp
+++ b/lib/Dialect/Torch/IR/TorchTypes.cpp
@@ -192,7 +192,8 @@ static bool isValidTorchDtype(Type dtype) {
   if (isa<Float16Type, BFloat16Type, Float32Type, Float64Type>(dtype))
     return true;
   if (isa<Float8E5M2Type, Float8E4M3FNType, Float8E5M2FNUZType,
-          Float8E4M3FNUZType, Float8E4M3B11FNUZType, Float4E2M1FNType>(dtype))
+          Float8E4M3FNUZType, Float8E4M3B11FNUZType, Float4E2M1FNType,
+          Float8E8M0FNUType>(dtype))
     return true;
 
   if (isa<Torch::StringType>(dtype))

--- a/lib/Dialect/Torch/Utils/TorchUpstream.cpp
+++ b/lib/Dialect/Torch/Utils/TorchUpstream.cpp
@@ -61,6 +61,12 @@ static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
   // this matrix has to be consistent with AT_FORALL_SCALAR_TYPES_WITH_COMPLEX
   // so that's why we have to add undefined as we are not sure what is the
   // corrent values for the type promotions in complex type cases.
+  //
+  // NOTE: This table only covers the first 16 scalar types (Byte through BFloat16).
+  // Newer types (Float8_*, Float4_*, QInt16) added after index 16 are not included
+  // in this promotion table. The uninitialized entries default to zero (Byte),
+  // which is incorrect. These newer types should not be used with promoteTypes()
+  // until this table is expanded with proper promotion rules from PyTorch.
   static constexpr ScalarType _promoteTypesLookup[static_cast<int>(
       ScalarType::NumOptions)][static_cast<int>(ScalarType::NumOptions)] = {
       /*        u1  i1  i2  i4  i8  f2  f4  f8  c2  c4  c8  b1  q1  q2  q3  bf*/

--- a/lib/Dialect/Torch/Utils/Utils.cpp
+++ b/lib/Dialect/Torch/Utils/Utils.cpp
@@ -92,6 +92,8 @@ torch_upstream::ScalarType Torch::getScalarTypeForType(Type type) {
     return torch_upstream::ScalarType::Float8_e4m3fnuz;
   if (isa<Float4E2M1FNType>(type))
     return torch_upstream::ScalarType::Float4_e2m1fn;
+  if (isa<Float8E8M0FNUType>(type))
+    return torch_upstream::ScalarType::Float8_e8m0fnu;
   std::string errorMsg = "Unhandled type in getScalarTypeForType: ";
   llvm::raw_string_ostream os(errorMsg);
   type.print(os);
@@ -173,6 +175,8 @@ Torch::getTypeForScalarType(MLIRContext *context,
     return Float8E4M3FNUZType::get(context);
   case torch_upstream::ScalarType::Float4_e2m1fn:
     return Float4E2M1FNType::get(context);
+  case torch_upstream::ScalarType::Float8_e8m0fnu:
+    return Float8E8M0FNUType::get(context);
   case torch_upstream::ScalarType::Undefined:
     return failure();
   default:
@@ -295,7 +299,7 @@ Value Torch::getConstantWithGivenDtypeAndValue(PatternRewriter &rewriter,
         loc, rewriter.getI64IntegerAttr((int64_t)value));
   if (dtype.isF64() || dtype.isF32() || dtype.isF16() || dtype.isBF16() ||
       isa<Float8E5M2Type, Float8E4M3FNType, Float8E5M2FNUZType,
-          Float8E4M3FNUZType, Float4E2M1FNType>(dtype))
+          Float8E4M3FNUZType, Float4E2M1FNType, Float8E8M0FNUType>(dtype))
     return rewriter.create<ConstantFloatOp>(loc,
                                             rewriter.getF64FloatAttr(value));
   llvm::report_fatal_error(
@@ -654,6 +658,8 @@ Type Torch::getDefaultAccType(PatternRewriter &rewriter, Type inputType) {
   if (inputType.isFloat8E4M3FNUZ())
     return rewriter.getF32Type();
   if (inputType.isFloat4E2M1FN())
+    return rewriter.getF32Type();
+  if (inputType.isFloat8E8M0FNU())
     return rewriter.getF32Type();
   if (inputType.isInteger(8))
     // this is an intentional deviation from CUDA (which accumulates i8 to i64)

--- a/lib/Dialect/Torch/Utils/Utils.cpp
+++ b/lib/Dialect/Torch/Utils/Utils.cpp
@@ -90,6 +90,8 @@ torch_upstream::ScalarType Torch::getScalarTypeForType(Type type) {
     return torch_upstream::ScalarType::Float8_e5m2fnuz;
   if (isa<Float8E4M3FNUZType>(type))
     return torch_upstream::ScalarType::Float8_e4m3fnuz;
+  if (isa<Float4E2M1FNType>(type))
+    return torch_upstream::ScalarType::Float4_e2m1fn;
   std::string errorMsg = "Unhandled type in getScalarTypeForType: ";
   llvm::raw_string_ostream os(errorMsg);
   type.print(os);
@@ -169,6 +171,8 @@ Torch::getTypeForScalarType(MLIRContext *context,
     return Float8E5M2FNUZType::get(context);
   case torch_upstream::ScalarType::Float8_e4m3fnuz:
     return Float8E4M3FNUZType::get(context);
+  case torch_upstream::ScalarType::Float4_e2m1fn:
+    return Float4E2M1FNType::get(context);
   case torch_upstream::ScalarType::Undefined:
     return failure();
   default:
@@ -289,7 +293,9 @@ Value Torch::getConstantWithGivenDtypeAndValue(PatternRewriter &rewriter,
       dtype.isInteger(8) || dtype.isInteger(1))
     return rewriter.create<ConstantIntOp>(
         loc, rewriter.getI64IntegerAttr((int64_t)value));
-  if (dtype.isF64() || dtype.isF32() || dtype.isF16() || dtype.isBF16())
+  if (dtype.isF64() || dtype.isF32() || dtype.isF16() || dtype.isBF16() ||
+      isa<Float8E5M2Type, Float8E4M3FNType, Float8E5M2FNUZType,
+          Float8E4M3FNUZType, Float4E2M1FNType>(dtype))
     return rewriter.create<ConstantFloatOp>(loc,
                                             rewriter.getF64FloatAttr(value));
   llvm::report_fatal_error(
@@ -646,6 +652,8 @@ Type Torch::getDefaultAccType(PatternRewriter &rewriter, Type inputType) {
   if (inputType.isFloat8E5M2FNUZ())
     return rewriter.getF32Type();
   if (inputType.isFloat8E4M3FNUZ())
+    return rewriter.getF32Type();
+  if (inputType.isFloat4E2M1FN())
     return rewriter.getF32Type();
   if (inputType.isInteger(8))
     // this is an intentional deviation from CUDA (which accumulates i8 to i64)

--- a/projects/onnx_c_importer/OnnxImporter.cpp
+++ b/projects/onnx_c_importer/OnnxImporter.cpp
@@ -357,6 +357,11 @@ MlirType ContextCache::ConvertTensorElementType(int elem_type) {
   case onnx::TensorProto::FLOAT8E5M2FNUZ:
     t = mlirFloat8E5M2FNUZTypeGet(context_);
     break;
+#ifdef onnx_TensorProto_DataType_FLOAT4E2M1
+  case onnx::TensorProto::FLOAT4E2M1:
+    t = mlirFloat4E2M1FNTypeGet(context_);
+    break;
+#endif
   default: {
     std::string msg = "Unknown ONNX tensor element type: ";
     msg.append(std::to_string(elem_type));

--- a/projects/onnx_c_importer/OnnxImporter.cpp
+++ b/projects/onnx_c_importer/OnnxImporter.cpp
@@ -362,6 +362,11 @@ MlirType ContextCache::ConvertTensorElementType(int elem_type) {
     t = mlirFloat4E2M1FNTypeGet(context_);
     break;
 #endif
+#ifdef onnx_TensorProto_DataType_FLOAT8E8M0
+  case onnx::TensorProto::FLOAT8E8M0:
+    t = mlirFloat8E8M0FNUTypeGet(context_);
+    break;
+#endif
   default: {
     std::string msg = "Unknown ONNX tensor element type: ";
     msg.append(std::to_string(elem_type));

--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -114,6 +114,7 @@ from ..ir import (
     Float8E4M3FNType,
     Float8E5M2FNUZType,
     Float8E4M3FNUZType,
+    Float8E8M0FNUType,
     F16Type,
     F32Type,
     F64Type,
@@ -199,6 +200,7 @@ OPTIONAL_TORCH_DTYPE_TO_MLIR_TYPE = {
     "float8_e5m2fnuz": lambda: Float8E5M2FNUZType.get(),
     "float8_e4m3fnuz": lambda: Float8E4M3FNUZType.get(),
     "float4_e2m1fn": lambda: Float4E2M1FNType.get(),
+    "float8_e8m0fnu": lambda: Float8E8M0FNUType.get(),
 }
 for dtype_str, mlir_type in OPTIONAL_TORCH_DTYPE_TO_MLIR_TYPE.items():
     if hasattr(torch, dtype_str):

--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -109,6 +109,7 @@ from ..ir import (
     FloatAttr,
     BF16Type,
     ComplexType,
+    Float4E2M1FNType,
     Float8E5M2Type,
     Float8E4M3FNType,
     Float8E5M2FNUZType,
@@ -197,6 +198,7 @@ OPTIONAL_TORCH_DTYPE_TO_MLIR_TYPE = {
     "float8_e4m3fn": lambda: Float8E4M3FNType.get(),
     "float8_e5m2fnuz": lambda: Float8E5M2FNUZType.get(),
     "float8_e4m3fnuz": lambda: Float8E4M3FNUZType.get(),
+    "float4_e2m1fn": lambda: Float4E2M1FNType.get(),
 }
 for dtype_str, mlir_type in OPTIONAL_TORCH_DTYPE_TO_MLIR_TYPE.items():
     if hasattr(torch, dtype_str):


### PR DESCRIPTION
Summary: TSIA.. We need a way to represent FP4 and F8E8 in torch dialect.

Relevant Issues: Towards GML-2563

Type of change: /kind feature

Test Plan: It compiles successfully when using it as local repo.